### PR TITLE
Fixes openrazer ebuild to function on 5.4 kernels

### DIFF
--- a/app-misc/openrazer/openrazer-9999.ebuild
+++ b/app-misc/openrazer/openrazer-9999.ebuild
@@ -35,8 +35,8 @@ DEPEND="${RDEPEND}
 "
 
 # This is a bit weird, but it's end result is what we want.
-BUILD_TARGETS="clean modules"
-BUILD_PARAMS="-j1 -C /usr/src/linux SUBDIRS=${S}/driver"
+BUILD_TARGETS="clean driver"
+BUILD_PARAMS="-j1 -C ${S} SUBDIRS=${S}/driver"
 MODULE_NAMES="
 	razerkbd(hid:${S}/driver)
 	razermouse(hid:${S}/driver)


### PR DESCRIPTION
Issue https://github.com/vifino/vifino-overlay/issues/22

Found through trial and error. This works with gentoo-sources-5.4.1.