### PR TITLE
Update daemonize-2.4.7.ebuild

### DIFF
--- a/dev-python/daemonize/daemonize-2.4.7.ebuild
+++ b/dev-python/daemonize/daemonize-2.4.7.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{3,4,5,6} pypy{,3} )
+PYTHON_COMPAT=( python2_7 python3_{3,4,5,6,7} pypy{,3} )
 
 inherit distutils-r1 python-r1
 


### PR DESCRIPTION
Since gentoo switched officialy to python3.7 instead of python3.6, to avoid a lot of adaptation for python_targets, this simply update may help lot of people (change tested ok on my system)