### PR TITLE
updated EAPI of d2to1 and batctl

### DIFF
--- a/dev-python/d2to1/d2to1-0.2.12_p1-r1.ebuild
+++ b/dev-python/d2to1/d2to1-0.2.12_p1-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 PYTHON_COMPAT=( python2_7 python3_{6..9} )
 

--- a/net-misc/batctl/batctl-2016.5.ebuild
+++ b/net-misc/batctl/batctl-2016.5.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=4
+EAPI=6
 
 inherit linux-info toolchain-funcs
 


### PR DESCRIPTION
Updated EAPI to 6. There are still ebuilds with old EAPI but just changing EAPI wasn't sufficient. See #49 