### PR TITLE
Add razer.conf.example

### DIFF
--- a/app-misc/openrazer/openrazer-9999.ebuild
+++ b/app-misc/openrazer/openrazer-9999.ebuild
@@ -92,6 +92,9 @@ src_install() {
 	exeinto "$(get_udevdir)"
 	doexe install_files/udev/razer_mount
 
+    insinto "/usr/share/${PN}"
+    newins daemon/resources/razer.conf razer.conf.example
+
 	if use daemon; then
 		newicon logo/openrazer-chroma.svg openrazer-daemon.svg
 		domenu install_files/desktop/openrazer-daemon.desktop


### PR DESCRIPTION
Closes #51

`openrazer-daemon` keeps complaining that this file is missing, because it is currently not installed by the ebuild. This commit addresses this issue.

Signed-off-by: Randall <ran.dall@icloud.com>