### PR TITLE
Add `doc` flag to various ebuilds

### DIFF
--- a/app-misc/openrazer/openrazer-9999.ebuild
+++ b/app-misc/openrazer/openrazer-9999.ebuild
@@ -14,7 +14,7 @@ EGIT_REPO_URI="https://github.com/${PN}/${PN}.git"
 LICENSE="GPL-2"
 SLOT="0"
 
-IUSE="+daemon client"
+IUSE="+daemon doc client"
 REQUIRED_USE="
 	daemon? ( ${PYTHON_REQUIRED_USE} )
 	client? ( daemon )
@@ -44,6 +44,8 @@ DEPEND="${RDEPEND}
 	app-misc/jq
 	virtual/linux-sources
 "
+
+DOCS=( README.markdown )
 
 # This is a bit weird, but it's end result is what we want.
 BUILD_TARGETS="clean driver"

--- a/app-misc/razergenie/razergenie-9999.ebuild
+++ b/app-misc/razergenie/razergenie-9999.ebuild
@@ -15,6 +15,8 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~amd64-linux"
 
+IUSE="doc"
+
 RDEPEND="
 	app-misc/openrazer[daemon]
 	app-misc/razer-test
@@ -26,6 +28,8 @@ RDEPEND="
 	dev-qt/qtwidgets
 "
 DEPEND="${RDEPEND}"
+
+DOCS=( README.markdown )
 
 src_configure() {
 	local emesonargs=(

--- a/dev-python/daemonize/daemonize-2.4.7.ebuild
+++ b/dev-python/daemonize/daemonize-2.4.7.ebuild
@@ -14,6 +14,9 @@ SRC_URI="https://github.com/thesharp/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ia64 ~ppc ~sparc ~x86"
-IUSE=""
+
+IUSE="doc"
 
 DEPEND=">=dev-python/setuptools-33.1.1[${PYTHON_USEDEP}]"
+
+DOCS=( README.markdown )

--- a/dev-python/daemonize/daemonize-2.5.0.ebuild
+++ b/dev-python/daemonize/daemonize-2.5.0.ebuild
@@ -15,4 +15,8 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
+IUSE="doc"
+
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
+
+DOCS=( README.markdown )


### PR DESCRIPTION
I noticed that some of the ebuilds has docs available but not setup for deployment with the ebuild. This commit address that...

@vifino I hope you don't mine me fixing these ebuilds. I'm learning how to make officially accepted ebuilds with the help of the folk of Gentoo IRC, and just trying to help. I should have one more PR coming for a versioned version of the ebuilds. Thanks man, for your help, support, and understanding...