### PR TITLE
Add category to .desktop file

### DIFF
--- a/app-misc/openrazer/openrazer-3.2.0.ebuild
+++ b/app-misc/openrazer/openrazer-3.2.0.ebuild
@@ -61,6 +61,10 @@ MODULE_NAMES="
 
 src_prepare() {
 	default
+	
+	# Add category to .desktop file
+	sed -i '/^Icon=*/a Categories=System;HardwareSettings;' \
+		install_files/desktop/openrazer-daemon.desktop || die "Failed sed replace of desktop file"
 
 	if use daemon; then
 		# Change path to icon

--- a/app-misc/openrazer/openrazer-3.2.0.ebuild
+++ b/app-misc/openrazer/openrazer-3.2.0.ebuild
@@ -42,7 +42,6 @@ RDEPEND="
 	client? ( dev-python/numpy[$PYTHON_USEDEP] )
 	"
 DEPEND="${RDEPEND}
-	sys-apps/sed
 	app-misc/jq
 	virtual/linux-sources
 "
@@ -60,8 +59,6 @@ MODULE_NAMES="
 "
 
 src_prepare() {
-	default
-	
 	# Add category to .desktop file
 	sed -i '/^Icon=*/a Categories=System;HardwareSettings;' \
 		install_files/desktop/openrazer-daemon.desktop || die "Failed sed replace of desktop file"
@@ -71,6 +68,8 @@ src_prepare() {
 		sed -i 's/^Icon=.*/Icon=openrazer-daemon/' \
 			install_files/desktop/openrazer-daemon.desktop || die "Failed sed replace of desktop file"
 	fi
+	
+	default
 }
 
 src_compile() {

--- a/app-misc/openrazer/openrazer-9999.ebuild
+++ b/app-misc/openrazer/openrazer-9999.ebuild
@@ -40,7 +40,6 @@ RDEPEND="
 	client? ( dev-python/numpy[$PYTHON_USEDEP] )
 	"
 DEPEND="${RDEPEND}
-	sys-apps/sed
 	app-misc/jq
 	virtual/linux-sources
 "
@@ -58,13 +57,17 @@ MODULE_NAMES="
 "
 
 src_prepare() {
-	default
+	# Add category to .desktop file
+	sed -i '/^Icon=*/a Categories=System;HardwareSettings;' \
+		install_files/desktop/openrazer-daemon.desktop || die "Failed sed replace of desktop file"
 
 	if use daemon; then
 		# Change path to icon
 		sed -i 's/^Icon=.*/Icon=openrazer-daemon/' \
 			install_files/desktop/openrazer-daemon.desktop || die "Failed sed replace of desktop file"
 	fi
+
+	default
 }
 
 src_compile() {


### PR DESCRIPTION
Currently, once the ebuild has emerged, the installation will put the application in 'Lost & Found' (while using KDE) due to the fact that the .desktop doesn't have a specified category. **This commit fixes the .desktop file and addresses the symptom.**